### PR TITLE
Fix table sort

### DIFF
--- a/frontend/src/components/Exams/Problem.js
+++ b/frontend/src/components/Exams/Problem.js
@@ -21,9 +21,8 @@ const problemReducer = (state, action) => {
 
       return {
         column: action.column,
-        data: _.sortBy(state.data, [action.column]),
-        direction:
-          state.direction === 'ascending' ? 'descending' : 'ascending',
+        data: _.sortBy(state.data, [action.column]).reverse(),
+        direction: 'descending',
       };
     default:
       throw new Error();

--- a/frontend/src/components/Problems/index.js
+++ b/frontend/src/components/Problems/index.js
@@ -29,9 +29,8 @@ const problemReducer = (state, action) => {
 
       return {
         column: action.column,
-        data: _.sortBy(state.data, [action.column]),
-        direction:
-          state.direction === 'ascending' ? 'descending' : 'ascending',
+        data: _.sortBy(state.data, [action.column]).reverse(),
+        direction: 'descending',
       };
     case 'CHANGE_FILTER':
       return {


### PR DESCRIPTION
Bug：如果交錯點不同 column，會發現都是升冪排序，但 indicator icon 會是 🔺🔻🔺🔻 交錯

改良行為：對使用者來說推薦度、出現次數、最近出現日期等都是愈大愈好，因此除了修復顯示錯誤外，將點第一下的預設排序改為降冪排序
